### PR TITLE
add output directories with generated files

### DIFF
--- a/keil.gitignore
+++ b/keil.gitignore
@@ -39,6 +39,10 @@
 *.__i
 *._ii
 
+# Generated output files
+/Listings/*
+/Objects/*
+
 # Debugger files
 *.ini  	# define exception below if needed
 


### PR DESCRIPTION
Both directories can be safely ignored, according to the Keil docs: http://www.keil.com/appnotes/files/apnt_279.pdf